### PR TITLE
Update jython to 2.7.1b3 for better Java 9 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
     <dependency>
       <groupId>org.python</groupId>
       <artifactId>jython-standalone</artifactId>
-      <version>2.7-b1</version>
+      <version>2.7.1b3</version>
     </dependency>
     <dependency>
       <groupId>com.googlecode.json-simple</groupId>


### PR DESCRIPTION
When combined with the current HEAD of Netty, this is enough to get all of the tests to pass on Java 9.
I suggest that this be pulled and a new release made which can then be incorporated into Netty.